### PR TITLE
Add unit tests for middleware and API validation

### DIFF
--- a/internal/api/logging_test.go
+++ b/internal/api/logging_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/NathanSanchezDev/go-insight/internal/models"
+)
+
+func TestValidateLogEntry(t *testing.T) {
+	valid := models.Log{ServiceName: "svc", Message: "msg", LogLevel: "INFO"}
+	if err := validateLogEntry(&valid); err != nil {
+		t.Fatalf("valid log returned error: %v", err)
+	}
+
+	missingService := models.Log{Message: "msg"}
+	if err := validateLogEntry(&missingService); err == nil {
+		t.Errorf("expected error for missing service name")
+	}
+
+	missingMessage := models.Log{ServiceName: "svc"}
+	if err := validateLogEntry(&missingMessage); err == nil {
+		t.Errorf("expected error for missing message")
+	}
+
+	invalidLevel := models.Log{ServiceName: "svc", Message: "msg", LogLevel: "BAD"}
+	if err := validateLogEntry(&invalidLevel); err == nil {
+		t.Errorf("expected error for bad log level")
+	}
+}

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/NathanSanchezDev/go-insight/internal/models"
+)
+
+func TestValidateMetric(t *testing.T) {
+	metric := models.EndpointMetric{
+		ServiceName: "svc",
+		Path:        "/",
+		Method:      "GET",
+		StatusCode:  200,
+		Duration:    1.0,
+		Source:      models.MetricSource{Language: "go"},
+	}
+	if err := validateMetric(&metric); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	badMethod := metric
+	badMethod.Method = "INVALID"
+	if err := validateMetric(&badMethod); err == nil {
+		t.Errorf("expected error for invalid method")
+	}
+
+	badStatus := metric
+	badStatus.StatusCode = 99
+	if err := validateMetric(&badStatus); err == nil {
+		t.Errorf("expected error for status code")
+	}
+
+	negativeDuration := metric
+	negativeDuration.Duration = -1
+	if err := validateMetric(&negativeDuration); err == nil {
+		t.Errorf("expected error for negative duration")
+	}
+
+	missingSource := metric
+	missingSource.Source.Language = ""
+	if err := validateMetric(&missingSource); err == nil {
+		t.Errorf("expected error for missing source language")
+	}
+}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestExtractAPIKey(t *testing.T) {
+	cases := []struct {
+		header http.Header
+		query  url.Values
+		want   string
+	}{
+		{header: http.Header{"Authorization": []string{"Bearer token123"}}, want: "token123"},
+		{header: http.Header{"Authorization": []string{"ApiKey abcdef"}}, want: "abcdef"},
+		{header: http.Header{"X-API-Key": []string{"headerkey"}}, want: "headerkey"},
+		{query: url.Values{"api_key": []string{"querykey"}}, want: "querykey"},
+		{header: http.Header{}, want: ""},
+	}
+
+	for _, c := range cases {
+		r := &http.Request{Header: c.header}
+		r.URL = &url.URL{RawQuery: c.query.Encode()}
+		got := extractAPIKey(r)
+		if got != c.want {
+			t.Errorf("extractAPIKey = %q, want %q", got, c.want)
+		}
+	}
+}
+
+func TestRequiresAuth(t *testing.T) {
+	if RequiresAuth("/health") {
+		t.Errorf("/health should not require auth")
+	}
+	if !RequiresAuth("/logs") {
+		t.Errorf("/logs should require auth")
+	}
+}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -14,7 +14,7 @@ func TestExtractAPIKey(t *testing.T) {
 	}{
 		{header: http.Header{"Authorization": []string{"Bearer token123"}}, want: "token123"},
 		{header: http.Header{"Authorization": []string{"ApiKey abcdef"}}, want: "abcdef"},
-		{header: http.Header{"X-API-Key": []string{"headerkey"}}, want: "headerkey"},
+               {header: http.Header{"X-Api-Key": []string{"headerkey"}}, want: "headerkey"},
 		{query: url.Values{"api_key": []string{"querykey"}}, want: "querykey"},
 		{header: http.Header{}, want: ""},
 	}

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -11,10 +11,10 @@ func TestGetClientIP(t *testing.T) {
 		t.Errorf("expected X-Forwarded-For to be used, got %s", ip)
 	}
 
-	r = &http.Request{Header: http.Header{"X-Real-IP": []string{"2.3.4.5"}}}
-	if ip := getClientIP(r); ip != "2.3.4.5" {
-		t.Errorf("expected X-Real-IP to be used, got %s", ip)
-	}
+       r = &http.Request{Header: http.Header{"X-Real-Ip": []string{"2.3.4.5"}}}
+        if ip := getClientIP(r); ip != "2.3.4.5" {
+                t.Errorf("expected X-Real-IP to be used, got %s", ip)
+        }
 
 	r = &http.Request{RemoteAddr: "3.4.5.6:789"}
 	if ip := getClientIP(r); ip != "3.4.5.6" {

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGetClientIP(t *testing.T) {
+	r := &http.Request{Header: http.Header{"X-Forwarded-For": []string{"1.2.3.4"}}}
+	if ip := getClientIP(r); ip != "1.2.3.4" {
+		t.Errorf("expected X-Forwarded-For to be used, got %s", ip)
+	}
+
+	r = &http.Request{Header: http.Header{"X-Real-IP": []string{"2.3.4.5"}}}
+	if ip := getClientIP(r); ip != "2.3.4.5" {
+		t.Errorf("expected X-Real-IP to be used, got %s", ip)
+	}
+
+	r = &http.Request{RemoteAddr: "3.4.5.6:789"}
+	if ip := getClientIP(r); ip != "3.4.5.6" {
+		t.Errorf("expected remote address host, got %s", ip)
+	}
+
+	r = &http.Request{RemoteAddr: "nonsense"}
+	if ip := getClientIP(r); ip != "nonsense" {
+		t.Errorf("expected entire remote addr when invalid, got %s", ip)
+	}
+}

--- a/internal/observability/tracing_test.go
+++ b/internal/observability/tracing_test.go
@@ -1,0 +1,14 @@
+package observability
+
+import "testing"
+
+func TestGenerateUUIDUnique(t *testing.T) {
+	a := GenerateUUID()
+	b := GenerateUUID()
+	if a == "" || b == "" {
+		t.Fatalf("uuid should not be empty")
+	}
+	if a == b {
+		t.Errorf("expected different uuids, got same")
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for extracting API keys and auth requirements
- add rate limit IP lookup tests
- add validation tests for logs and metrics
- test UUID generation

## Testing
- `go test ./...` *(fails: proxy.golang.org access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850d355ea908331bd86212ddad813c5