### PR TITLE
Improve getClientIP XFF parsing

### DIFF
--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -81,11 +81,8 @@ func isRequestAllowed(clientIP string) (bool, int) {
 
 func getClientIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if strings.Contains(xff, ",") {
-			parts := strings.Split(xff, ",")
-			return strings.TrimSpace(parts[0])
-		}
-		return strings.TrimSpace(xff)
+		parts := strings.SplitN(xff, ",", 2)
+		return strings.TrimSpace(parts[0])
 	}
 	if xri := r.Header.Get("X-Real-IP"); xri != "" {
 		return xri

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -80,7 +81,11 @@ func isRequestAllowed(clientIP string) (bool, int) {
 
 func getClientIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		return xff
+		if strings.Contains(xff, ",") {
+			parts := strings.Split(xff, ",")
+			return strings.TrimSpace(parts[0])
+		}
+		return strings.TrimSpace(xff)
 	}
 	if xri := r.Header.Get("X-Real-IP"); xri != "" {
 		return xri

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -28,3 +28,15 @@ func TestGetClientIPMultipleXFF(t *testing.T) {
 		t.Errorf("expected 1.2.3.4, got %s", ip)
 	}
 }
+
+func TestGetClientIPTrimSpaces(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("X-Forwarded-For", " 1.2.3.4 , 5.6.7.8 ")
+	ip := getClientIP(req)
+	if ip != "1.2.3.4" {
+		t.Errorf("expected 1.2.3.4, got %s", ip)
+	}
+}

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGetClientIPSingleXFF(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	ip := getClientIP(req)
+	if ip != "1.2.3.4" {
+		t.Errorf("expected 1.2.3.4, got %s", ip)
+	}
+}
+
+func TestGetClientIPMultipleXFF(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
+	ip := getClientIP(req)
+	if ip != "1.2.3.4" {
+		t.Errorf("expected 1.2.3.4, got %s", ip)
+	}
+}


### PR DESCRIPTION
## Summary
- improve `getClientIP` in the rate limit middleware
- return the first IP when `X-Forwarded-For` contains multiple values
- add tests for single and multiple XFF values

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850d51887408331a06738861910248e