### PR TITLE
Fix stray asterisk in security docs

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -275,7 +275,7 @@ Planned security improvements include:
 For security-related questions or to report security vulnerabilities:
 
 - Create an issue on GitHub for general security questions
-- For security vulnerabilities, please email nathansanchezdev@outlook.com*
+- For security vulnerabilities, please email nathansanchezdev@outlook.com
 
 ---
 


### PR DESCRIPTION
## Summary
- remove a stray `*` from the security contact address

## Testing
- `go test ./...` *(fails: proxy.golang.org forbidden)*
- `go vet ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850d51b9a6c8331be91536d7e2bab46