### PR TITLE
Implement bulk log insertion endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -201,6 +201,36 @@ curl -X POST http://localhost:8080/logs \
 - `401 Unauthorized`: Authentication required
 - `429 Too Many Requests`: Rate limit exceeded
 
+### POST /logs/bulk
+
+Insert multiple log entries in a single request.
+
+**Authentication**: Required
+
+**Request Body**: Array of log objects matching the POST `/logs` schema.
+
+**Request**:
+```bash
+curl -X POST http://localhost:8080/logs/bulk \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '[{"service_name":"svc","message":"m1"},{"service_name":"svc","message":"m2"}]'
+```
+
+**Response**:
+```json
+[
+  { "id": 1, "service_name": "svc", "log_level": "", "message": "m1" },
+  { "id": 2, "service_name": "svc", "log_level": "", "message": "m2" }
+]
+```
+
+**Status Codes**:
+- `201 Created`: Logs inserted successfully
+- `400 Bad Request`: Validation error
+- `401 Unauthorized`: Authentication required
+- `429 Too Many Requests`: Rate limit exceeded
+
 ---
 
 ## Metrics API

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,7 +43,7 @@ Go-Insight is an observability platform designed to collect, store, and visualiz
 - ✅ **Advanced authentication options** (JWT, role-based access)
 
 ### Bulk Operations & Performance
-- 🔄 **Bulk insertion endpoints** for high-volume data ingestion (POST /logs/bulk)
+- ✅ **Bulk insertion endpoints** for high-volume data ingestion (POST /logs/bulk)
 - 🔄 **Aggregation endpoints** for metrics analysis (averages, percentiles)
 - 🔄 **Background job processing** for data retention and cleanup
 - 🔄 **Connection pooling optimization** for database efficiency

--- a/internal/api/logging.go
+++ b/internal/api/logging.go
@@ -332,6 +332,9 @@ func PostLogsBulk(logs []models.Log) error {
 	return tx.Commit()
 }
 
+// postLogsBulkFunc allows tests to mock bulk insertion.
+var postLogsBulkFunc = PostLogsBulk
+
 // PostLogsBulkHandler handles POST /logs/bulk for inserting multiple logs.
 func PostLogsBulkHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -355,7 +358,7 @@ func PostLogsBulkHandler(w http.ResponseWriter, r *http.Request) {
 		sanitizeLogEntry(&entries[i])
 	}
 
-	if err := PostLogsBulk(entries); err != nil {
+	if err := postLogsBulkFunc(entries); err != nil {
 		http.Error(w, "Failed to save logs", http.StatusInternalServerError)
 		return
 	}

--- a/internal/api/logging.go
+++ b/internal/api/logging.go
@@ -271,3 +271,96 @@ func PostLogHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(logEntry)
 }
+
+// PostLogsBulk inserts multiple log entries in a single transaction.
+func PostLogsBulk(logs []models.Log) error {
+	tx, err := db.DB.BeginTx(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+
+	stmt, err := tx.PrepareContext(context.Background(), `INSERT INTO logs
+                (service_name, log_level, message, timestamp, trace_id, span_id, metadata)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                RETURNING id`)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+
+	for i := range logs {
+		entry := &logs[i]
+
+		if entry.Timestamp.IsZero() {
+			entry.Timestamp = time.Now()
+		}
+
+		if entry.TraceID.String == "" {
+			entry.TraceID.Valid = false
+		} else {
+			entry.TraceID.Valid = true
+		}
+
+		if entry.SpanID.String == "" {
+			entry.SpanID.Valid = false
+		} else {
+			entry.SpanID.Valid = true
+		}
+
+		if entry.Metadata == nil || len(*entry.Metadata) == 0 {
+			empty := json.RawMessage("{}")
+			entry.Metadata = &empty
+		}
+
+		metadataBytes := *entry.Metadata
+
+		if err := stmt.QueryRowContext(context.Background(),
+			entry.ServiceName,
+			entry.LogLevel,
+			entry.Message,
+			entry.Timestamp,
+			entry.TraceID,
+			entry.SpanID,
+			metadataBytes,
+		).Scan(&entry.ID); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// PostLogsBulkHandler handles POST /logs/bulk for inserting multiple logs.
+func PostLogsBulkHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var entries []models.Log
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&entries); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	for i := range entries {
+		if err := validateLogEntry(&entries[i]); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		sanitizeLogEntry(&entries[i])
+	}
+
+	if err := PostLogsBulk(entries); err != nil {
+		http.Error(w, "Failed to save logs", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(entries)
+}

--- a/internal/api/logging_bulk_test.go
+++ b/internal/api/logging_bulk_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/NathanSanchezDev/go-insight/internal/models"
+)
+
+// TestPostLogsBulkHandlerSuccess verifies that the handler accepts valid input
+// and returns a 201 status code.
+func TestPostLogsBulkHandlerSuccess(t *testing.T) {
+	// stub bulk insertion to avoid database dependency
+	called := false
+	postLogsBulkFunc = func(entries []models.Log) error {
+		called = true
+		return nil
+	}
+	defer func() { postLogsBulkFunc = PostLogsBulk }()
+
+	body := `[{"service_name":"svc","message":"m1"},{"service_name":"svc","message":"m2"}]`
+	req := httptest.NewRequest(http.MethodPost, "/logs/bulk", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+
+	PostLogsBulkHandler(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", rr.Code)
+	}
+	if !called {
+		t.Fatalf("postLogsBulkFunc was not called")
+	}
+}
+
+// TestPostLogsBulkHandlerBadRequest verifies that invalid JSON returns 400.
+func TestPostLogsBulkHandlerBadRequest(t *testing.T) {
+	postLogsBulkFunc = func(entries []models.Log) error { return nil }
+	defer func() { postLogsBulkFunc = PostLogsBulk }()
+
+	req := httptest.NewRequest(http.MethodPost, "/logs/bulk", bytes.NewBufferString("{"))
+	rr := httptest.NewRecorder()
+
+	PostLogsBulkHandler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+// TestPostLogsBulkHandlerValidation verifies that invalid log entries are rejected.
+func TestPostLogsBulkHandlerValidation(t *testing.T) {
+	postLogsBulkFunc = func(entries []models.Log) error { return nil }
+	defer func() { postLogsBulkFunc = PostLogsBulk }()
+
+	body := `[{"message":"m1"}]` // missing service_name
+	req := httptest.NewRequest(http.MethodPost, "/logs/bulk", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+
+	PostLogsBulkHandler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -17,6 +17,7 @@ func SetupRoutes() *mux.Router {
 	// Logs endpoints
 	router.HandleFunc("/logs", GetLogsHandler).Methods("GET")
 	router.HandleFunc("/logs", PostLogHandler).Methods("POST")
+	router.HandleFunc("/logs/bulk", PostLogsBulkHandler).Methods("POST")
 
 	// Traces endpoints
 	router.HandleFunc("/traces", GetTracesHandler).Methods("GET")

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -144,10 +144,11 @@ func parseJWT(token, secret string) (*jwtClaims, error) {
 }
 
 var EndpointRoles = map[string]string{
-	"/metrics": "user",
-	"/logs":    "user",
-	"/traces":  "user",
-	"/spans":   "user",
+	"/logs":      "user",
+	"/logs/bulk": "user",
+	"/metrics":   "user",
+	"/spans":     "user",
+	"/traces":    "user",
 }
 
 func hasRole(userRole, required string) bool {

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -14,7 +14,7 @@ func TestExtractAPIKey(t *testing.T) {
 	}{
 		{header: http.Header{"Authorization": []string{"Bearer token123"}}, want: "token123"},
 		{header: http.Header{"Authorization": []string{"ApiKey abcdef"}}, want: "abcdef"},
-               {header: http.Header{"X-Api-Key": []string{"headerkey"}}, want: "headerkey"},
+		{header: http.Header{"X-Api-Key": []string{"headerkey"}}, want: "headerkey"},
 		{query: url.Values{"api_key": []string{"querykey"}}, want: "querykey"},
 		{header: http.Header{}, want: ""},
 	}
@@ -35,5 +35,8 @@ func TestRequiresAuth(t *testing.T) {
 	}
 	if !RequiresAuth("/logs") {
 		t.Errorf("/logs should require auth")
+	}
+	if !RequiresAuth("/logs/bulk") {
+		t.Errorf("/logs/bulk should require auth")
 	}
 }


### PR DESCRIPTION
## Summary
- add POST /logs/bulk endpoint for inserting multiple logs at once
- wire new route and auth role
- document the new bulk endpoint
- mark roadmap item as complete
- order the EndpointRoles map alphabetically

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68516e60ce9c83318ccf47a6956b76cd